### PR TITLE
Fix ctrl-Z handling

### DIFF
--- a/signal_unix.go
+++ b/signal_unix.go
@@ -8,8 +8,9 @@ import (
 )
 
 func handleCtrlZ() {
-	p, err := os.FindProcess(os.Getpid())
+	pid := os.Getpid()
+	pgrp, err := syscall.Getpgid(pid)
 	if err == nil {
-		p.Signal(syscall.SIGTSTP)
+		syscall.Kill(-pgrp, syscall.SIGTSTP)
 	}
 }


### PR DESCRIPTION
To correctly mimic the behavior of a terminal we need to send SIGTSTP to the whole foreground process group, instead of just sending it to ourselves.

Fixes go-delve/delve#3605